### PR TITLE
Add CASCADE ON UPDATE to all foreign keys referencing auth.users

### DIFF
--- a/supabase/migrations/20251015094309_add_cascade_update_to_user_foreign_keys.sql
+++ b/supabase/migrations/20251015094309_add_cascade_update_to_user_foreign_keys.sql
@@ -1,0 +1,107 @@
+-- Add CASCADE ON UPDATE to all foreign keys referencing auth.users(id)
+-- This is important for account linking scenarios where users might link accounts
+-- with different emails using Supabase auth admin API
+
+-- When a user's ID changes (during account linking), all related records should update automatically
+-- DELETE CASCADE is already in place, this migration adds UPDATE CASCADE
+
+-- 1. Update chat_histories.account_id foreign key
+ALTER TABLE public.chat_histories
+  DROP CONSTRAINT IF EXISTS chat_histories_account_id_fkey,
+  ADD CONSTRAINT chat_histories_account_id_fkey
+    FOREIGN KEY (account_id)
+    REFERENCES auth.users(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- 2. Update daemon_auth_sessions.user_id foreign key
+ALTER TABLE public.daemon_auth_sessions
+  DROP CONSTRAINT IF EXISTS daemon_auth_sessions_user_id_fkey,
+  ADD CONSTRAINT daemon_auth_sessions_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES auth.users(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- 3. Update projects.user_id foreign key
+ALTER TABLE public.projects
+  DROP CONSTRAINT IF EXISTS projects_user_id_fkey,
+  ADD CONSTRAINT projects_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES auth.users(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- 4. Update project_shares.shared_by_user_id foreign key
+ALTER TABLE public.project_shares
+  DROP CONSTRAINT IF EXISTS project_shares_shared_by_user_id_fkey,
+  ADD CONSTRAINT project_shares_shared_by_user_id_fkey
+    FOREIGN KEY (shared_by_user_id)
+    REFERENCES auth.users(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- 5. Update project_shares.shared_with_user_id foreign key
+ALTER TABLE public.project_shares
+  DROP CONSTRAINT IF EXISTS project_shares_shared_with_user_id_fkey,
+  ADD CONSTRAINT project_shares_shared_with_user_id_fkey
+    FOREIGN KEY (shared_with_user_id)
+    REFERENCES auth.users(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- 6. Update project_organization_shares.shared_by_user_id foreign key
+ALTER TABLE public.project_organization_shares
+  DROP CONSTRAINT IF EXISTS project_organization_shares_shared_by_user_id_fkey,
+  ADD CONSTRAINT project_organization_shares_shared_by_user_id_fkey
+    FOREIGN KEY (shared_by_user_id)
+    REFERENCES auth.users(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- 7. Update active_sessions.user_id foreign key
+ALTER TABLE public.active_sessions
+  DROP CONSTRAINT IF EXISTS active_sessions_user_id_fkey,
+  ADD CONSTRAINT active_sessions_user_id_fkey
+    FOREIGN KEY (user_id)
+    REFERENCES auth.users(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE;
+
+-- Rollback instructions:
+-- To rollback, recreate the constraints with ON UPDATE NO ACTION:
+--
+-- ALTER TABLE public.chat_histories
+--   DROP CONSTRAINT IF EXISTS chat_histories_account_id_fkey,
+--   ADD CONSTRAINT chat_histories_account_id_fkey
+--     FOREIGN KEY (account_id) REFERENCES auth.users(id) ON DELETE CASCADE ON UPDATE NO ACTION;
+--
+-- ALTER TABLE public.daemon_auth_sessions
+--   DROP CONSTRAINT IF EXISTS daemon_auth_sessions_user_id_fkey,
+--   ADD CONSTRAINT daemon_auth_sessions_user_id_fkey
+--     FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE ON UPDATE NO ACTION;
+--
+-- ALTER TABLE public.projects
+--   DROP CONSTRAINT IF EXISTS projects_user_id_fkey,
+--   ADD CONSTRAINT projects_user_id_fkey
+--     FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE ON UPDATE NO ACTION;
+--
+-- ALTER TABLE public.project_shares
+--   DROP CONSTRAINT IF EXISTS project_shares_shared_by_user_id_fkey,
+--   ADD CONSTRAINT project_shares_shared_by_user_id_fkey
+--     FOREIGN KEY (shared_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE ON UPDATE NO ACTION;
+--
+-- ALTER TABLE public.project_shares
+--   DROP CONSTRAINT IF EXISTS project_shares_shared_with_user_id_fkey,
+--   ADD CONSTRAINT project_shares_shared_with_user_id_fkey
+--     FOREIGN KEY (shared_with_user_id) REFERENCES auth.users(id) ON DELETE CASCADE ON UPDATE NO ACTION;
+--
+-- ALTER TABLE public.project_organization_shares
+--   DROP CONSTRAINT IF EXISTS project_organization_shares_shared_by_user_id_fkey,
+--   ADD CONSTRAINT project_organization_shares_shared_by_user_id_fkey
+--     FOREIGN KEY (shared_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE ON UPDATE NO ACTION;
+--
+-- ALTER TABLE public.active_sessions
+--   DROP CONSTRAINT IF EXISTS active_sessions_user_id_fkey,
+--   ADD CONSTRAINT active_sessions_user_id_fkey
+--     FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE ON UPDATE NO ACTION;


### PR DESCRIPTION
Add migration to update all foreign key constraints to support CASCADE ON UPDATE for account linking scenarios where users might link accounts with different emails using Supabase auth admin API.

Changes:
- Updates 7 foreign key constraints across all tables
- Adds ON UPDATE CASCADE to user_id and account_id columns
- Maintains existing ON DELETE CASCADE behavior
- Enables automatic data updates when user IDs change during account merges

Affected tables:
- chat_histories (account_id)
- daemon_auth_sessions (user_id)
- projects (user_id)
- project_shares (shared_by_user_id, shared_with_user_id)
- project_organization_shares (shared_by_user_id)
- active_sessions (user_id)

This migration is critical for the account linking feature, ensuring data integrity when merging accounts with different email addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)