### PR TITLE
feat(desktop): Add recently opened workspaces service

### DIFF
--- a/apps/desktop/src/main/database/IDatabase.ts
+++ b/apps/desktop/src/main/database/IDatabase.ts
@@ -84,4 +84,38 @@ export interface IDatabase {
    * @returns Array of all agent states
    */
   loadAllAgentStatuses(): Promise<CodingAgentState[]>;
+
+  // ==========================================================================
+  // Recent Workspaces Methods
+  // ==========================================================================
+
+  /**
+   * Track a workspace as recently opened (upsert with LRU eviction)
+   * @param path - Workspace path
+   * @param name - Workspace name
+   * @param gitInfo - Optional git metadata
+   */
+  trackRecentWorkspace(
+    path: string,
+    name: string,
+    gitInfo?: { branch?: string; remote?: string }
+  ): Promise<void>;
+
+  /**
+   * Get recent workspaces sorted by last opened
+   * @param limit - Maximum number of workspaces to return (default 10)
+   */
+  getRecentWorkspaces(limit?: number): Promise<{
+    path: string;
+    name: string;
+    lastOpenedAt: string;
+    openCount: number;
+    git?: { branch?: string; remote?: string };
+  }[]>;
+
+  /**
+   * Remove a workspace from recent list
+   * @param path - Workspace path to remove
+   */
+  removeRecentWorkspace(path: string): Promise<void>;
 }

--- a/apps/desktop/src/main/preload.ts
+++ b/apps/desktop/src/main/preload.ts
@@ -480,3 +480,49 @@ contextBridge.exposeInMainWorld('gitAPI', {
     }
   },
 } as GitAPI);
+
+// Recent workspace entry type
+export interface RecentWorkspaceEntry {
+  path: string;
+  name: string;
+  lastOpenedAt: string;
+  openCount: number;
+  git?: {
+    branch?: string;
+    remote?: string;
+  };
+}
+
+// Type definitions for the recent workspace API
+export interface RecentWorkspaceAPI {
+  /** Track a workspace as recently opened */
+  trackRecent: (
+    path: string,
+    name: string,
+    gitInfo?: { branch?: string; remote?: string }
+  ) => Promise<void>;
+  /** Get recent workspaces sorted by last opened */
+  getRecent: (limit?: number) => Promise<RecentWorkspaceEntry[]>;
+  /** Remove a workspace from recent list */
+  removeRecent: (path: string) => Promise<void>;
+}
+
+// Expose recent workspace API
+contextBridge.exposeInMainWorld('recentWorkspaceAPI', {
+  trackRecent: async (
+    path: string,
+    name: string,
+    gitInfo?: { branch?: string; remote?: string }
+  ) => {
+    await unwrapResponse(
+      ipcRenderer.invoke('workspace:track-recent', path, name, gitInfo)
+    );
+  },
+  getRecent: (limit?: number) =>
+    unwrapResponse<RecentWorkspaceEntry[]>(
+      ipcRenderer.invoke('workspace:get-recent', limit)
+    ),
+  removeRecent: async (path: string) => {
+    await unwrapResponse(ipcRenderer.invoke('workspace:remove-recent', path));
+  },
+} as RecentWorkspaceAPI);

--- a/apps/desktop/src/renderer/WorkspaceSelectionModal.css
+++ b/apps/desktop/src/renderer/WorkspaceSelectionModal.css
@@ -143,3 +143,95 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* Recent workspaces section */
+.recent-workspaces-section {
+  margin-bottom: 16px;
+}
+
+.recent-workspaces-section h4 {
+  font-size: 13px;
+  color: #cccccc;
+  margin: 0 0 10px 0;
+  font-weight: 600;
+}
+
+.recent-workspaces-list {
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #3c3c3c;
+  border-radius: 4px;
+  background: #252526;
+}
+
+.recent-workspace-item {
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  border-bottom: 1px solid #3c3c3c;
+  transition: background-color 0.15s ease;
+}
+
+.recent-workspace-item:last-child {
+  border-bottom: none;
+}
+
+.recent-workspace-item:hover {
+  background: #2a2d2e;
+}
+
+.recent-workspace-item.selected {
+  background: #094771;
+}
+
+.workspace-name {
+  color: #cccccc;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.workspace-path {
+  color: #858585;
+  font-size: 11px;
+  font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+  margin-bottom: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-git {
+  color: #3794ff;
+  font-size: 11px;
+  font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+}
+
+.section-divider {
+  margin: 16px 0;
+  text-align: center;
+  color: #6e6e6e;
+  font-size: 12px;
+  position: relative;
+}
+
+.section-divider::before,
+.section-divider::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 40%;
+  height: 1px;
+  background: #3c3c3c;
+}
+
+.section-divider::before {
+  left: 0;
+}
+
+.section-divider::after {
+  right: 0;
+}

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -4,7 +4,7 @@
  * Extends Window interface with Electron IPC APIs.
  */
 
-import type { ElectronAPI, WorktreeAPI, CodingAgentAPI, AgentStatusAPI, LLMAPI, RepresentationAPI, GitAPI } from '../main/preload';
+import type { ElectronAPI, WorktreeAPI, CodingAgentAPI, AgentStatusAPI, LLMAPI, RepresentationAPI, GitAPI, RecentWorkspaceAPI } from '../main/preload';
 
 // Extended ShellAPI with directory dialog (added for workspace selection)
 interface ExtendedShellAPI {
@@ -25,6 +25,7 @@ declare global {
     shellAPI?: ExtendedShellAPI;
     canvasAPI?: import('../main/preload').CanvasAPI;
     gitAPI?: GitAPI;
+    recentWorkspaceAPI?: RecentWorkspaceAPI;
   }
 }
 

--- a/apps/desktop/src/renderer/hooks/index.ts
+++ b/apps/desktop/src/renderer/hooks/index.ts
@@ -2,3 +2,4 @@ export { useCanvasPersistence } from './useCanvasPersistence';
 export * from './canvasConverters';
 export { useWorkspaceInheritance, type WorkspaceInheritanceResult } from './useWorkspaceInheritance';
 export { useWorkspaceDisplay, type WorkspaceDisplayResult, type WorkspaceSource } from './useWorkspaceDisplay';
+export { useRecentWorkspaces } from './useRecentWorkspaces';

--- a/apps/desktop/src/renderer/hooks/useRecentWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/useRecentWorkspaces.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { RecentWorkspaceEntry } from '../../main/preload';
+
+export function useRecentWorkspaces(limit: number = 10) {
+  const [workspaces, setWorkspaces] = useState<RecentWorkspaceEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!window.recentWorkspaceAPI) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const entries = await window.recentWorkspaceAPI.getRecent(limit);
+      setWorkspaces(entries);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load recent workspaces');
+      console.error('[useRecentWorkspaces] Failed to fetch:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const trackWorkspace = useCallback(
+    async (
+      path: string,
+      name: string,
+      gitInfo?: { branch?: string; remote?: string }
+    ) => {
+      if (!window.recentWorkspaceAPI) return;
+
+      try {
+        await window.recentWorkspaceAPI.trackRecent(path, name, gitInfo);
+        await refresh();
+      } catch (err) {
+        console.error('[useRecentWorkspaces] Failed to track:', err);
+      }
+    },
+    [refresh]
+  );
+
+  const removeWorkspace = useCallback(
+    async (path: string) => {
+      if (!window.recentWorkspaceAPI) return;
+
+      try {
+        await window.recentWorkspaceAPI.removeRecent(path);
+        await refresh();
+      } catch (err) {
+        console.error('[useRecentWorkspaces] Failed to remove:', err);
+      }
+    },
+    [refresh]
+  );
+
+  return {
+    workspaces,
+    isLoading,
+    error,
+    refresh,
+    trackWorkspace,
+    removeWorkspace,
+  };
+}


### PR DESCRIPTION
## Summary

- Add a service to track recently opened workspaces, helping users quickly reopen previously used workspaces
- WorkspaceSelectionModal now displays recent workspaces at the top for quick access
- Implements clean separation of concerns: modal is pure presentation, container handles business logic

## Changes

- **Database layer**: Add `recent_workspaces` SQLite table with LRU eviction (max 20)
- **IPC bridge**: Expose `recentWorkspaceAPI` for main ↔ renderer communication  
- **Hook**: Create `useRecentWorkspaces` for data fetching and state management
- **View**: Update `WorkspaceSelectionModal` as pure presentation (receives data via props)
- **Container**: `AgentNode` coordinates business logic and passes data to modal
- **Styling**: VS Code-style recent workspaces list with git branch display

## Architecture

```
AgentNode (container)
    ↓ uses useRecentWorkspaces hook
    ↓ passes recentWorkspaces + callbacks as props
WorkspaceSelectionModal (view)
    ↓ user selects workspace
    ↓ calls onSelect(path)
AgentNode.handleWorkspaceSelect
    ↓ calls trackWorkspace (from hook)
    ↓ updates node attachments
```

## Test plan

- [ ] Open desktop app with `npm run dev:desktop`
- [ ] Create an AgentNode and select a workspace
- [ ] Close and reopen the workspace selection modal - verify recent workspace appears
- [ ] Select multiple workspaces - verify LRU ordering (most recent first)
- [ ] Verify git branch is displayed for git repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)