### PR TITLE
fix: resolve reader issues across vscode, cursor, factory, and codex

### DIFF
--- a/packages/shared/src/readers/__tests__/codex-reader.test.ts
+++ b/packages/shared/src/readers/__tests__/codex-reader.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatHistory } from '../../loaders/types.js';
 import {
   CodexLoader,
@@ -60,12 +60,14 @@ describe('codex-reader', () => {
     });
 
     it('should include today as the first folder', () => {
-      const result = calculateDateFoldersToScan(1);
-      const today = new Date();
-      const year = today.getFullYear();
-      const month = String(today.getMonth() + 1).padStart(2, '0');
-      const day = String(today.getDate()).padStart(2, '0');
-      expect(result[0]).toBe(`${year}/${month}/${day}`);
+      const fixedDate = new Date('2025-01-15T12:00:00.000Z');
+      vi.setSystemTime(fixedDate);
+      try {
+        const result = calculateDateFoldersToScan(1);
+        expect(result[0]).toBe('2025/01/15');
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 
@@ -194,7 +196,7 @@ describe('codex-reader', () => {
     it('should use default lookbackDays of 7 when not specified', () => {
       const result = readCodexHistories(testSessionsDir);
       // Should find sessions from today (within 7 days)
-      expect(result.length).toBeGreaterThanOrEqual(0);
+      expect(result).toHaveLength(1);
     });
   });
 

--- a/packages/shared/src/readers/__tests__/project-aggregator.test.ts
+++ b/packages/shared/src/readers/__tests__/project-aggregator.test.ts
@@ -208,7 +208,7 @@ describe('project-aggregator', () => {
       expect(result[0]?.workspaceIds).toContain('ws-789');
     });
 
-    it('should use earlier lastActivity when newer source has older timestamp', () => {
+    it('should keep latest lastActivity when merging projects', () => {
       const cursorProjects: ProjectInfo[] = [
         {
           name: 'my-app',

--- a/packages/shared/src/readers/cursor-reader.ts
+++ b/packages/shared/src/readers/cursor-reader.ts
@@ -129,7 +129,6 @@ export function detectStorageFormat(
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='cursorDiskKV'")
         .get();
       if (cursorDiskKV) {
-        db.close();
         return 'cursorDiskKV';
       }
 
@@ -138,7 +137,6 @@ export function detectStorageFormat(
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='ItemTable'")
         .get();
       if (itemTable) {
-        db.close();
         return 'ItemTable';
       }
     } finally {

--- a/packages/shared/src/readers/factory-reader.ts
+++ b/packages/shared/src/readers/factory-reader.ts
@@ -180,7 +180,7 @@ export function readFactoryHistories(sessionsDir?: string, options?: LoaderOptio
       }
     }
   } catch {
-    // Return empty array on error
+    // Return accumulated results on error
   }
 
   return histories;

--- a/packages/shared/src/readers/vscode-reader.ts
+++ b/packages/shared/src/readers/vscode-reader.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import type { IDatabaseLoader } from '../loaders/interfaces.js';
 import type { ChatHistory, LoaderOptions, ProjectInfo, SessionMetadata } from '../loaders/types.js';
@@ -70,8 +71,10 @@ export function parseWorkspaceInfo(workspaceDir: string): WorkspaceInfo | null {
     let folder: string | undefined;
     if (workspaceJson.folder) {
       const uri = workspaceJson.folder;
-      if (typeof uri === 'string') {
-        folder = uri.replace('file://', '');
+      if (typeof uri === 'string' && uri.startsWith('file://')) {
+        folder = fileURLToPath(uri);
+      } else if (typeof uri === 'string') {
+        folder = uri;
       } else if (uri && typeof uri === 'object' && 'path' in uri) {
         folder = String(uri.path);
       }


### PR DESCRIPTION
- Use fileURLToPath for cross-platform file URI handling in vscode-reader
- Remove explicit db.close() calls to prevent double-close bug in cursor-reader
- Fix misleading comment in factory-reader error handling
- Rename test to match actual behavior in project-aggregator tests
- Fix time-sensitive test with vi.setSystemTime in codex-reader tests
- Replace no-op assertion with meaningful check in codex-reader tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cross-platform file URI handling in the VSCode reader and prevent a double-close bug in the Cursor reader. Stabilizes date-sensitive Codex tests and aligns a project-aggregator test name with actual behavior.

- **Bug Fixes**
  - VSCode reader: use fileURLToPath for file:// URIs to handle Windows and Unix paths.
  - Cursor reader: remove premature db.close() calls; cleanup happens in finally.
  - Codex tests: set a fixed system time for date checks and replace a no-op assertion with a real length check.
  - Project aggregator tests: rename a test to reflect merging behavior.
  - Factory reader: clarify error handling comment to indicate partial results are returned.

<sup>Written for commit 40c522e567c7d90af8923727e840a671d246cf7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

